### PR TITLE
issue-#17 // code 128 -> subsets (A, C) Add

### DIFF
--- a/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128.java
+++ b/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128.java
@@ -4,12 +4,12 @@ import fr.w3blog.zpl.model.PrinterOptions;
 import fr.w3blog.zpl.utils.ZplUtils;
 
 /**
- * Element to create a bar code 128
- * 
+ * Element to create a bar code 128 subset B (default subset)
+ * <p>
  * Zpl command : ^BC
- * 
+ * <p>
  * @author matthiasvets
- * 
+ *
  */
 public class ZebraBarCode128 extends ZebraBarCode {
 

--- a/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128A.java
+++ b/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128A.java
@@ -1,0 +1,61 @@
+package fr.w3blog.zpl.model.element;
+
+import fr.w3blog.zpl.model.PrinterOptions;
+import fr.w3blog.zpl.utils.ZplUtils;
+
+/**
+ * Element to create a bar code 128 subset A
+ * <p>
+ * Zpl command ^BC
+ * <p>
+ * add >9 after the ^FD
+ *
+ * @author foameraserblue
+ */
+public class ZebraBarCode128A extends ZebraBarCode {
+    private boolean checkDigit43 = false;
+
+    public ZebraBarCode128A(int positionX, int positionY, String text) {
+        super(positionX, positionY, text);
+    }
+
+    public ZebraBarCode128A(int positionX, int positionY, String text, int barCodeHeigth) {
+        super(positionX, positionY, text, barCodeHeigth);
+    }
+
+    public ZebraBarCode128A(int positionX, int positionY, String text, int barCodeHeigth, int moduleWidth, int wideBarRatio) {
+        super(positionX, positionY, text, barCodeHeigth, moduleWidth, wideBarRatio);
+    }
+
+    public ZebraBarCode128A(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, int moduleWidth, int wideBarRatio) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, moduleWidth, wideBarRatio);
+    }
+
+    public ZebraBarCode128A(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, int moduleWidth, int wideBarRatio, boolean checkDigit43) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, moduleWidth, wideBarRatio);
+        this.checkDigit43 = checkDigit43;
+    }
+
+    public ZebraBarCode128A(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, boolean showTextInterpretationAbove) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, showTextInterpretationAbove);
+    }
+
+    @Override
+    public String getZplCode(PrinterOptions printerOptions) {
+        StringBuilder zpl = getStartZplCodeBuilder();
+        zpl.append(ZplUtils.zplCommandSautLigne("BC", zebraRotation.getLetter(), barCodeHeigth, showTextInterpretation, showTextInterpretationAbove, checkDigit43));
+        zpl.append("^FD");
+        zpl.append(">9");
+        zpl.append(text);
+        zpl.append(ZplUtils.zplCommandSautLigne("FS"));
+        return zpl.toString();
+    }
+
+    public boolean isCheckDigit43() {
+        return checkDigit43;
+    }
+
+    public void setCheckDigit43(boolean checkDigit43) {
+        this.checkDigit43 = checkDigit43;
+    }
+}

--- a/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128C.java
+++ b/src/main/java/fr/w3blog/zpl/model/element/ZebraBarCode128C.java
@@ -1,0 +1,62 @@
+package fr.w3blog.zpl.model.element;
+
+import fr.w3blog.zpl.model.PrinterOptions;
+import fr.w3blog.zpl.utils.ZplUtils;
+
+/**
+ * Element to create a bar code 128 subset C
+ * <p>
+ * Zpl command ^BC
+ * <p>
+ * add >; after the ^FD
+ *
+ * @author foameraserblue
+ */
+public class ZebraBarCode128C extends ZebraBarCode {
+
+    private boolean checkDigit43 = false;
+
+    public ZebraBarCode128C(int positionX, int positionY, String text) {
+        super(positionX, positionY, text);
+    }
+
+    public ZebraBarCode128C(int positionX, int positionY, String text, int barCodeHeigth) {
+        super(positionX, positionY, text, barCodeHeigth);
+    }
+
+    public ZebraBarCode128C(int positionX, int positionY, String text, int barCodeHeigth, int moduleWidth, int wideBarRatio) {
+        super(positionX, positionY, text, barCodeHeigth, moduleWidth, wideBarRatio);
+    }
+
+    public ZebraBarCode128C(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, int moduleWidth, int wideBarRatio) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, moduleWidth, wideBarRatio);
+    }
+
+    public ZebraBarCode128C(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, int moduleWidth, int wideBarRatio, boolean checkDigit43) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, moduleWidth, wideBarRatio);
+        this.checkDigit43 = checkDigit43;
+    }
+
+    public ZebraBarCode128C(int positionX, int positionY, String text, int barCodeHeigth, boolean showTextInterpretation, boolean showTextInterpretationAbove) {
+        super(positionX, positionY, text, barCodeHeigth, showTextInterpretation, showTextInterpretationAbove);
+    }
+
+    @Override
+    public String getZplCode(PrinterOptions printerOptions) {
+        StringBuilder zpl = getStartZplCodeBuilder();
+        zpl.append(ZplUtils.zplCommandSautLigne("BC", zebraRotation.getLetter(), barCodeHeigth, showTextInterpretation, showTextInterpretationAbove, checkDigit43));
+        zpl.append("^FD");
+        zpl.append(">;");
+        zpl.append(text);
+        zpl.append(ZplUtils.zplCommandSautLigne("FS"));
+        return zpl.toString();
+    }
+
+    public boolean isCheckDigit43() {
+        return checkDigit43;
+    }
+
+    public void setCheckDigit43(boolean checkDigit43) {
+        this.checkDigit43 = checkDigit43;
+    }
+}

--- a/src/test/java/fr/w3blog/zpl/model/element/ZebraBarCode128ATest.java
+++ b/src/test/java/fr/w3blog/zpl/model/element/ZebraBarCode128ATest.java
@@ -1,0 +1,11 @@
+package fr.w3blog.zpl.model.element;
+
+import junit.framework.TestCase;
+
+public class ZebraBarCode128ATest extends TestCase {
+
+    public void testZplOutput() {
+        ZebraBarCode128A barcode = new ZebraBarCode128A(70, 1000, "0235600703875191516022937128", 190, false, 4, 2);
+        assertEquals("^FT70,1000\n^BY4,2,190\n^BCN,190,N,N,N\n^FD>90235600703875191516022937128^FS\n", barcode.getZplCode(null));
+    }
+}

--- a/src/test/java/fr/w3blog/zpl/model/element/ZebraBarCode128CTest.java
+++ b/src/test/java/fr/w3blog/zpl/model/element/ZebraBarCode128CTest.java
@@ -1,0 +1,11 @@
+package fr.w3blog.zpl.model.element;
+
+import junit.framework.TestCase;
+
+public class ZebraBarCode128CTest extends TestCase {
+
+    public void testZplOutput() {
+        ZebraBarCode128C barcode = new ZebraBarCode128C(70, 1000, "0235600703875191516022937128", 190, false, 4, 2);
+        assertEquals("^FT70,1000\n^BY4,2,190\n^BCN,190,N,N,N\n^FD>;0235600703875191516022937128^FS\n", barcode.getZplCode(null));
+    }
+}


### PR DESCRIPTION
A new subset object was created without adding subset-related fields to the existing object.

For compatibility with existing code, ZebraBarCode128 is not renamed (B is added)

As a comment, I wrote down that the ZebraBarCode128 object performs logic with subset B.